### PR TITLE
Fix YouTube video download callback

### DIFF
--- a/src/services/telegram-bot.js
+++ b/src/services/telegram-bot.js
@@ -98,8 +98,9 @@ class TelegramBotService {
 
         this.bot.on('callback_query', async (query) => {
             const chatId = query.message.chat.id;
-            const [format, ...urlParts] = query.data.split(':');
-            const url = urlParts.join(':');
+            const separatorIndex = query.data.indexOf(':');
+            const format = query.data.substring(0, separatorIndex);
+            const url = query.data.substring(separatorIndex + 1);
             const callbackId = `${query.id}_${format}`;
 
             if (this.processedCallbacks.has(callbackId)) {


### PR DESCRIPTION
## Summary
- fix callback query URL parsing for Telegram video downloads

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_68714dfc4d14832eb3ce24167d6db895